### PR TITLE
SD boot fix

### DIFF
--- a/recipes-kernel/linux/files/sls16xx-sd.dtsi
+++ b/recipes-kernel/linux/files/sls16xx-sd.dtsi
@@ -21,8 +21,8 @@
 
 /* SD */
 &usdhc2 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&pinctrl_usdhc2>;
+    pinctrl-names = "default";
+    pinctrl-0 = <&pinctrl_usdhc2>;
     disable-wp;
-	status ="okay";
+    status ="okay";
 };

--- a/recipes-kernel/linux/files/sls16xx-sd.dtsi
+++ b/recipes-kernel/linux/files/sls16xx-sd.dtsi
@@ -7,31 +7,22 @@
 /* IO multiplexing */
 &iomuxc {
 	/* SD */
-	pinctrl_qspi: qspi {
-		fsl,pins = <
-			MX6UL_PAD_NAND_WP_B__QSPI_A_SCLK      0x70a1
-			MX6UL_PAD_NAND_READY_B__QSPI_A_DATA00 0x70a1
-			MX6UL_PAD_NAND_CE0_B__QSPI_A_DATA01   0x70a1
-			MX6UL_PAD_NAND_CE1_B__QSPI_A_DATA02   0x70a1
-			MX6UL_PAD_NAND_CLE__QSPI_A_DATA03     0x70a1
-			MX6UL_PAD_NAND_DQS__QSPI_A_SS0_B      0x70a1
-		>;
-	};
+    pinctrl_usdhc2: usdhc2grp {
+            fsl,pins = <
+                    MX6UL_PAD_NAND_RE_B__USDHC2_CLK     0x10069
+                    MX6UL_PAD_NAND_WE_B__USDHC2_CMD     0x17059
+                    MX6UL_PAD_NAND_DATA00__USDHC2_DATA0 0x17059
+                    MX6UL_PAD_NAND_DATA01__USDHC2_DATA1 0x17059
+                    MX6UL_PAD_NAND_DATA02__USDHC2_DATA2 0x17059
+                    MX6UL_PAD_NAND_DATA03__USDHC2_DATA3 0x17059
+            >;
+    };
 };
 
 /* SD */
-&qspi {
+&usdhc2 {
 	pinctrl-names = "default";
-	pinctrl-0 = <&pinctrl_qspi>;
-	status = "okay";
-	ddrsmp=<0>;
-
-	flash0: n25q256a@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
-		compatible = "winbond,n25q256a";
-		spi-max-frequency = <29000000>;
-		spi-nor,ddr-quad-read-dummy = <6>;
-		reg = <0>;
-	};
+	pinctrl-0 = <&pinctrl_usdhc2>;
+    disable-wp;
+	status ="okay";
 };

--- a/recipes-kernel/linux/files/sls16xx-sd.dtsi
+++ b/recipes-kernel/linux/files/sls16xx-sd.dtsi
@@ -4,25 +4,26 @@
  * published by the Free Software Foundation.
  */
 
+/* SD */
+&usdhc2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_usdhc2>;
+	disable-wp;
+	status ="okay";
+};
+
 /* IO multiplexing */
 &iomuxc {
 	/* SD */
-    pinctrl_usdhc2: usdhc2grp {
-            fsl,pins = <
-                    MX6UL_PAD_NAND_RE_B__USDHC2_CLK     0x10069
-                    MX6UL_PAD_NAND_WE_B__USDHC2_CMD     0x17059
-                    MX6UL_PAD_NAND_DATA00__USDHC2_DATA0 0x17059
-                    MX6UL_PAD_NAND_DATA01__USDHC2_DATA1 0x17059
-                    MX6UL_PAD_NAND_DATA02__USDHC2_DATA2 0x17059
-                    MX6UL_PAD_NAND_DATA03__USDHC2_DATA3 0x17059
-            >;
-    };
+	pinctrl_usdhc2: usdhc2 {
+		fsl,pins = <
+			MX6UL_PAD_NAND_RE_B__USDHC2_CLK     0x10069
+			MX6UL_PAD_NAND_WE_B__USDHC2_CMD     0x17059
+			MX6UL_PAD_NAND_DATA00__USDHC2_DATA0 0x17059
+			MX6UL_PAD_NAND_DATA01__USDHC2_DATA1 0x17059
+			MX6UL_PAD_NAND_DATA02__USDHC2_DATA2 0x17059
+			MX6UL_PAD_NAND_DATA03__USDHC2_DATA3 0x17059
+		>;
+	};
 };
 
-/* SD */
-&usdhc2 {
-    pinctrl-names = "default";
-    pinctrl-0 = <&pinctrl_usdhc2>;
-    disable-wp;
-    status ="okay";
-};


### PR DESCRIPTION
I'm not sure but I think that there is no spi flash memory on somlabs boards, and usdhc2 were not configured.
Now non WiFi visionSOM6ULL boots up